### PR TITLE
Change skip link "Menu" to "Pied de page"

### DIFF
--- a/src/components/SkipLink.vue
+++ b/src/components/SkipLink.vue
@@ -6,7 +6,7 @@
                 <a class="fr-link" href="#main"  @click.stop>Contenu</a>
             </li>
             <li>
-                <a class="rf-link" href="#footer"  @click.stop>Pied de page</a>
+                <a class="fr-link" href="#footer"  @click.stop>Pied de page</a>
             </li>
         </ul>
     </div>

--- a/src/components/SkipLink.vue
+++ b/src/components/SkipLink.vue
@@ -6,7 +6,7 @@
                 <a class="fr-link" href="#main"  @click.stop>Contenu</a>
             </li>
             <li>
-                <a class="fr-link" href="#nav"  @click.stop>Menu</a>
+                <a class="rf-link" href="#footer"  @click.stop>Pied de page</a>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
As there is only one [Tab] key press to reach the Menu… the skip link "Menu" seems useless.
On the other hand, reaching the footer quickly could be useful.