### PR TITLE
Fix : supprime le scrollBehaviour personnalisé du router.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -147,14 +147,4 @@ library.add(
     })
     Vue.component('font-awesome', FontAwesomeIcon)
     head.htmlAttrs = { lang: 'fr', 'data-fr-scheme': 'system' }
-
-    // Don't scroll to top when dynamically changing
-    // query params on PiDila checklist
-    router.options.scrollBehavior = (to, from, savedPosition) => {
-      const PIDILA_PATH = '/outils/checklist-pidila/'
-
-      if (to.path === PIDILA_PATH && from.path === PIDILA_PATH) {
-        return {}
-      }
-    }
   }


### PR DESCRIPTION
Evite de se retrouver au milieu du document quand on change de page.