### PR TITLE
feat: migrate newsletter from MailChimp to Brevo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Puis modifiez le fichier `.env` avec vos valeurs :
 1. Lancer le serveur de développement Gridsome :
 
 ```bash
-gridsome develop
+yarn develop
 ```
 
 2. Lancer le serveur proxy PHP pour les appels à l'API Grist du browser (inscription, demande d'accompagnement, candidature) :

--- a/src/pages/Newsletter.vue
+++ b/src/pages/Newsletter.vue
@@ -1,7 +1,6 @@
 <template>
   <Layout>
     <div class="dg-content fr-px-2w">
-
       <nav role="navigation" class="fr-breadcrumb" aria-label="vous êtes ici :">
         <ol class="fr-breadcrumb__list">
           <li>
@@ -14,85 +13,271 @@
       </nav>
 
       <h1 lang="en">Newsletter</h1>
-      <p class="fr-text--lead">DesignGouv, c’est aussi des événements et des rencontres pour faire vivre la culture design au sein des administrations.</p>
-      <p>Et parfois des offres d’emploi ou propositions de collaboration. C’est pourquoi nous vous proposons de partager vos compétences.</p>
+      <p class="fr-text--lead">
+        DesignGouv, c'est aussi des événements et des rencontres pour faire
+        vivre la culture design au sein des administrations.
+      </p>
+      <p>
+        Et parfois des offres d'emploi ou propositions de collaboration. C'est
+        pourquoi nous vous proposons de partager vos compétences.
+      </p>
 
       <div class="dg-content dg-content--xs fr-mt-6w">
-          <form action="https://gouv.us5.list-manage.com/subscribe/post?u=c921e95d674341b87fd4fb6e6&amp;id=bc185cd5f1" method="post" name="mc-embedded-subscribe-form" rel="noreferrer noopener">
+        <form
+          action="https://sibforms.com/serve/MUIFAIB5vtgiHecAcSy-dibeNcjH3CrhFBrTieylWyUXfu7xMMgaJprVy5cjLq1-SBFOl2jYEZ25_ke1Hzw0LHc2aBoQtFuCgGiKzTB73QhJRtt722LfPhXMY7PY-T60wV9eBmLttylfbhzx4WI5aWUWJQQ7ldjP3bn8kqc8ex6oP2LsIIrEw6ZJtRKDvjqmEVvWkCwvguQoP3I3"
+          method="post"
+          id="sib-form"
+          data-type="subscription"
+        >
+          <div class="fr-form-group">
+            <label class="fr-label" for="EMAIL" aria-describedby="format">
+              Votre adresse électronique (obligatoire)
+            </label>
+            <p class="fr-hint-text" id="format">Au format prenom@mail.fr</p>
+            <input
+              type="email"
+              value=""
+              name="EMAIL"
+              class="fr-input"
+              id="EMAIL"
+              required
+              autocomplete="email"
+            />
+          </div>
 
-            <div class="fr-form-group">
-              <label class="fr-label" for="mce-EMAIL" aria-describedby="format">
-                Votre adresse électronique (obligatoire)
-              </label>
-              <p class="fr-hint-text" id="format">Au format prenom@mail.fr</p>
-              <input type="email" value="" name="EMAIL" class="fr-input" id="mce-EMAIL" required autocomplete="email">
-            </div>
+          <div class="fr-form-group">
+            <label class="fr-label" for="ORGANISATION"
+              >Vous travaillez dans...</label
+            >
+            <select
+              class="fr-select"
+              name="ORGANISATION"
+              id="ORGANISATION"
+              required
+            >
+              <option value="" selected disabled hidden>
+                Selectionnez une option
+              </option>
+              <option value="La fonction publique de l'État">
+                La fonction publique de l'État
+              </option>
+              <option value="La fonction publique des collectivités">
+                La fonction publique des collectivités
+              </option>
+              <option value="Le privé">Le privé</option>
+              <option value="Je suis étudiant(e)">Je suis étudiant(e)</option>
+              <option value="Autre">Autre</option>
+            </select>
+          </div>
 
-            <div class="fr-form-group">
-              <label class="fr-label" for="mce-group[21897]">Vous travaillez dans...</label>
-              <select  class="fr-select" name="group[21897]" id="mce-group[21897]">
-                <option value="" selected disabled hidden>Selectionnez une option</option>
-                <option value="1">La fonction publique de l'État</option>
-                <option value="2">La fonction publique des collectivités</option>
-                <option value="4">Le privé</option>
-                <option value="8">Je suis étudiant(e)</option>
-                <option value="16">Autre</option>
-              </select>
-            </div>
-
-            <div class="fr-form-group">
-              <fieldset class="fr-fieldset">
-                <legend class="fr-fieldset__legend fr-text--regular" id='checkboxes-legend'>
-                    Votre expertise professionnelle
-                </legend>
-                <div class="fr-fieldset__content">
-                  <div class="fr-checkbox-group"><input type="checkbox" value="32" name="group[21901][32]" id="mce-group[21901]-21901-0"><label class="fr-label" for="mce-group[21901]-21901-0">Designer UX</label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="512" name="group[21901][512]" id="mce-group[21901]-21901-1"><label class="fr-label" for="mce-group[21901]-21901-1">Designer UI</label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="2048" name="group[21901][2048]" id="mce-group[21901]-21901-2"><label class="fr-label" for="mce-group[21901]-21901-2">Designer de services</label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="64" name="group[21901][64]" id="mce-group[21901]-21901-3"><label class="fr-label" for="mce-group[21901]-21901-3">Chef / cheffe de produit (<span lang="en">product owner</span>)</label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="262144" name="group[21901][262144]" id="mce-group[21901]-21901-4"><label class="fr-label" for="mce-group[21901]-21901-4">Chercheur / chercheuse utilisateur (<span lang="en">user researcher</span>)</label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="1024" name="group[21901][1024]" id="mce-group[21901]-21901-5"><label class="fr-label" for="mce-group[21901]-21901-5" lang="en">Scrum master</label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="128" name="group[21901][128]" id="mce-group[21901]-21901-6"><label class="fr-label" for="mce-group[21901]-21901-6">Développeur / développeuse <span class="fr-pl-1v" lang="en">front-end</span></label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="4096" name="group[21901][4096]" id="mce-group[21901]-21901-7"><label class="fr-label" for="mce-group[21901]-21901-7">Développeur / développeuse  <span class="fr-pl-1v"lang="en">back-end</span></label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="8192" name="group[21901][8192]" id="mce-group[21901]-21901-8"><label class="fr-label" for="mce-group[21901]-21901-8">Développeur / développeuse accessibilité</label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="16384" name="group[21901][16384]" id="mce-group[21901]-21901-9"><label class="fr-label" for="mce-group[21901]-21901-9">Spécialiste en sciences comportementales</label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="32768" name="group[21901][32768]" id="mce-group[21901]-21901-10"><label class="fr-label" for="mce-group[21901]-21901-10">Rédacteur (<span lang="en">UX writer</span>)</label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="65536" name="group[21901][65536]" id="mce-group[21901]-21901-11"><label class="fr-label" for="mce-group[21901]-21901-11">Juriste</label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="131072" name="group[21901][131072]" id="mce-group[21901]-21901-12"><label class="fr-label" for="mce-group[21901]-21901-12" lang="en">Data scientist</label></div>
-                  <div class="fr-checkbox-group"><input type="checkbox" value="256" name="group[21901][256]" id="mce-group[21901]-21901-13"><label class="fr-label" for="mce-group[21901]-21901-13">Autre</label></div>
+          <div class="fr-form-group">
+            <fieldset class="fr-fieldset">
+              <legend
+                class="fr-fieldset__legend fr-text--regular"
+                id="checkboxes-legend"
+              >
+                Votre expertise professionnelle
+              </legend>
+              <div class="fr-fieldset__content">
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Designer UX"
+                    name="JOB_TITLE[]"
+                    id="job-designer-ux"
+                  /><label class="fr-label" for="job-designer-ux"
+                    >Designer UX</label
+                  >
                 </div>
-              </fieldset>
-            </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Designer UI"
+                    name="JOB_TITLE[]"
+                    id="job-designer-ui"
+                  /><label class="fr-label" for="job-designer-ui"
+                    >Designer UI</label
+                  >
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Designer de services"
+                    name="JOB_TITLE[]"
+                    id="job-designer-services"
+                  /><label class="fr-label" for="job-designer-services"
+                    >Designer de services</label
+                  >
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Product Owner"
+                    name="JOB_TITLE[]"
+                    id="job-po"
+                  /><label class="fr-label" for="job-po"
+                    >Chef / cheffe de produit (<span lang="en"
+                      >product owner</span
+                    >)</label
+                  >
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="User Researcher"
+                    name="JOB_TITLE[]"
+                    id="job-researcher"
+                  /><label class="fr-label" for="job-researcher"
+                    >Chercheur / chercheuse utilisateur (<span lang="en"
+                      >user researcher</span
+                    >)</label
+                  >
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Scrum Master"
+                    name="JOB_TITLE[]"
+                    id="job-scrum"
+                  /><label class="fr-label" for="job-scrum" lang="en"
+                    >Scrum master</label
+                  >
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Développeur front-end"
+                    name="JOB_TITLE[]"
+                    id="job-frontend"
+                  /><label class="fr-label" for="job-frontend"
+                    >Développeur / développeuse
+                    <span class="fr-pl-1v" lang="en">front-end</span></label
+                  >
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Développeur back-end"
+                    name="JOB_TITLE[]"
+                    id="job-backend"
+                  /><label class="fr-label" for="job-backend"
+                    >Développeur / développeuse
+                    <span class="fr-pl-1v" lang="en">back-end</span></label
+                  >
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Développeur accessibilité"
+                    name="JOB_TITLE[]"
+                    id="job-a11y"
+                  /><label class="fr-label" for="job-a11y"
+                    >Développeur / développeuse accessibilité</label
+                  >
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Spécialiste sciences comportementales"
+                    name="JOB_TITLE[]"
+                    id="job-behavioral"
+                  /><label class="fr-label" for="job-behavioral"
+                    >Spécialiste en sciences comportementales</label
+                  >
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="UX Writer"
+                    name="JOB_TITLE[]"
+                    id="job-writer"
+                  /><label class="fr-label" for="job-writer"
+                    >Rédacteur (<span lang="en">UX writer</span>)</label
+                  >
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Juriste"
+                    name="JOB_TITLE[]"
+                    id="job-juriste"
+                  /><label class="fr-label" for="job-juriste">Juriste</label>
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Data Scientist"
+                    name="JOB_TITLE[]"
+                    id="job-data"
+                  /><label class="fr-label" for="job-data" lang="en"
+                    >Data scientist</label
+                  >
+                </div>
+                <div class="fr-checkbox-group">
+                  <input
+                    type="checkbox"
+                    value="Autre"
+                    name="JOB_TITLE[]"
+                    id="job-autre"
+                  /><label class="fr-label" for="job-autre">Autre</label>
+                </div>
+              </div>
+            </fieldset>
+          </div>
 
-            <!-- <div id="mce-responses" class="clear">
-              <div class="response" id="mce-error-response" style="display:none"></div>
-              <div class="response" id="mce-success-response" style="display:none"></div>
-            </div> -->
+          <p>
+            <small
+              >Les données recueillies sur ce formulaire sont traitées par les
+              équipes de la DINUM. Elles nous permettent de vous informer via
+              e-mail des actualités de la communauté DesignGouv.</small
+            >
+          </p>
+          <p>
+            <small
+              >Conformément à la règlementation, vous disposez d'un droit
+              d'opposition et d'un droit à la limitation du traitement de
+              données vous concernant, ainsi que d'un droit d'accès, de
+              rectification, de portabilité et d'effacement de vos données. Vous
+              pouvez exercer vos droits en nous écrivant à l'adresse
+              électronique suivante : contact@design.numerique.gouv.fr.</small
+            >
+          </p>
 
-            <p><small>Les données recueillies sur ce formulaire sont traitées par les équipes de la DINUM. Elles nous permettent de vous informer via e-mail des actualités de la communauté DesignGouv.</small></p>
-            <p><small>Conformément à la règlementation, vous disposez d’un droit d’opposition et d’un droit à la limitation du traitement de données vous concernant, ainsi que d’un droit d’accès, de rectification, de portabilité et d’effacement de vos données. Vous pouvez exercer vos droits en nous écrivant à l’adresse électronique suivante : contact@design.numerique.gouv.fr.</small></p>
+          <input
+            type="text"
+            name="email_address_check"
+            value=""
+            class="input--hidden"
+          />
+          <input type="hidden" name="locale" value="fr" />
 
-            <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-            <div style="position: absolute; left: -5000px;" aria-hidden="true"><input title="les vrais gens savent" type="text" name="b_c921e95d674341b87fd4fb6e6_bc185cd5f1" tabindex="-1" value=""></div>
-            <div class="clear"><input type="submit" value="Je m'inscris à la newsletter" title="Je m'inscris à la newsletter" name="subscribe" id="mc-embedded-subscribe" class="fr-btn"></div>
-
-          </form>
+          <div class="clear">
+            <input
+              type="submit"
+              value="Je m'inscris à la newsletter"
+              name="subscribe"
+              id="sib-form-submit"
+              class="fr-btn"
+            />
+          </div>
+        </form>
       </div>
-
     </div>
   </Layout>
 </template>
 
-
 <script>
-  export default {
-    metaInfo: {
-      title: "Newsletter",
-      description: "DesignGouv, c’est aussi des événements, des rencontres et des discussions pour faire vivre la culture design au sein des administrations. Rejoignez-nous !",
-      meta: [{
+export default {
+  metaInfo: {
+    title: "Newsletter",
+    description:
+      "DesignGouv, c'est aussi des événements, des rencontres et des discussions pour faire vivre la culture design au sein des administrations. Rejoignez-nous !",
+    meta: [
+      {
         name: "robots",
-        content: "noindex"
-      }],
-    }
-  }
+        content: "noindex",
+      },
+    ],
+  },
+};
 </script>

--- a/src/pages/formulaire/succes-newsletter.vue
+++ b/src/pages/formulaire/succes-newsletter.vue
@@ -1,0 +1,27 @@
+<template>
+  <Layout>
+    <div class="dg-content dg-text-center fr-px-2w fr-pt-4w">
+      <h1 class="dg-text-blue fr-display-xs">Merci pour votre inscription !</h1>
+      <p class="fr-text--lead fr-mb-3w">
+        Vous êtes désormais inscrit(e) à la newsletter DesignGouv.
+      </p>
+      <g-link to="/" class="fr-btn">Retourner à l'accueil</g-link>
+    </div>
+  </Layout>
+</template>
+
+<script>
+export default {
+  metaInfo: {
+    title: "Inscription confirmée à la newsletter DesignGouv",
+    description:
+      "Votre inscription à la newsletter DesignGouv a bien été prise en compte.",
+    meta: [
+      {
+        name: "robots",
+        content: "noindex",
+      },
+    ],
+  },
+};
+</script>


### PR DESCRIPTION
This pull request contains : 
- [x] Brevo form integration instead of MailChimp old one
- [x] Confirmation page (redirection url configuration in Brevo form config panel)